### PR TITLE
Reporting SDS offence Exemptions for PRS investigation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/prs/AllPrisonersPrsEligibility.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/prs/AllPrisonersPrsEligibility.kt
@@ -7,27 +7,38 @@ class AllPrisonersPrsEligibility(
   private val agencyId: String,
   private var prisonerCount: Int = 0,
   private var prisonersEligible: Int = 0,
+  private var prisonersEligibleIncludingSdsExclusions: Int = 0,
   private var reasonsForIneligibility: MutableMap<PrsIneligibilityReason, Int> = mutableMapOf(
     PrsIneligibilityReason.CATEGORY to 0,
     PrsIneligibilityReason.TIME_LEFT_TO_SERVE to 0,
     PrsIneligibilityReason.INCENTIVE_LEVEL to 0,
     PrsIneligibilityReason.ESCAPE to 0,
   ),
+  private var sdsExcludedOffenceCodeCount: MutableMap<String, Int> = mutableMapOf(),
 ) {
   fun addPrisoner(prisonerPrsEligibility: PrisonerPrsEligibility) {
     prisonerCount++
     if (prisonerPrsEligibility.isEligible) {
       prisonersEligible++
     }
+    if (prisonerPrsEligibility.isEligibleIncludingSdsExclusions) {
+      prisonersEligibleIncludingSdsExclusions++
+    }
     prisonerPrsEligibility.reasonForIneligibility.forEach {
       this.reasonsForIneligibility[it] = reasonsForIneligibility[it]?.plus(1) ?: 1
+    }
+    prisonerPrsEligibility.sdsExcludedOffenceCodes.forEach {
+      sdsExcludedOffenceCodeCount[it] = (sdsExcludedOffenceCodeCount[it] ?: 0) + 1
     }
   }
 
   fun logResult() {
-    val logStringBuilder = StringBuilder().append("PRS_ELIGIBILITY_INVESTIGATION: $agencyId, $prisonerCount, $prisonersEligible")
+    val logStringBuilder = StringBuilder().append("PRS_ELIGIBILITY_INVESTIGATION: $agencyId, $prisonerCount, $prisonersEligible, $prisonersEligibleIncludingSdsExclusions")
     this.reasonsForIneligibility.forEach {
-      logStringBuilder.append(", ${it.value}")
+      logStringBuilder.append(", ${it.key}: ${it.value}")
+    }
+    this.sdsExcludedOffenceCodeCount.forEach {
+      logStringBuilder.append(", ${it.key}: ${it.value}")
     }
     log.info(logStringBuilder.toString())
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/prs/PrisonerPrsEligibility.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/prs/PrisonerPrsEligibility.kt
@@ -4,7 +4,11 @@ import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.enum.Pr
 
 class PrisonerPrsEligibility(
   val reasonForIneligibility: List<PrsIneligibilityReason>,
+  val sdsExcludedOffenceCodes: List<String>,
 ) {
   val isEligible: Boolean
     get() = reasonForIneligibility.isEmpty()
+
+  val isEligibleIncludingSdsExclusions: Boolean
+    get() = this.isEligible && sdsExcludedOffenceCodes.isEmpty()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrisonerPrsEligibilityCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrisonerPrsEligibilityCalculator.kt
@@ -8,6 +8,7 @@ import java.time.LocalDate
 
 class PrisonerPrsEligibilityCalculator(
   private val prisoner: Prisoner,
+  private val sdsExcludedOffenceCodes: List<String>,
 ) {
   private fun isCategoryCOrClosed(): Boolean {
     return this.prisoner.category == Prisoner.CATEGORY_C || this.prisoner.category == Prisoner.CATEGORY_R
@@ -37,6 +38,10 @@ class PrisonerPrsEligibilityCalculator(
     } ?: false
   }
 
+  private fun prisonersSdsExcludedOffenceCodes(): List<String> {
+    return prisoner.convictedOffencesResponse?.allConvictedOffences?.map { it.offenceCode }?.filter { sdsExcludedOffenceCodes.contains(it) } ?: emptyList()
+  }
+
   fun calculate(): PrisonerPrsEligibility {
     val reasonForIneligibility = mutableListOf<PrsIneligibilityReason>()
     if (!isCategoryCOrClosed()) {
@@ -53,6 +58,7 @@ class PrisonerPrsEligibilityCalculator(
     }
     return PrisonerPrsEligibility(
       reasonForIneligibility,
+      prisonersSdsExcludedOffenceCodes(),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrsEligibilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrsEligibilityService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.services.prs
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.ManageOffencesApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.prs.AllPrisonersPrsEligibility
@@ -10,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.respons
 class PrsEligibilityService(
   private val prisonerSearchApiClient: PrisonerSearchApiClient,
   private val prisonApiClient: PrisonApiClient,
+  private val manageOffencesApiClient: ManageOffencesApiClient,
 ) {
   fun report() {
     val allPrisons = prisonApiClient.findPrisons()
@@ -24,14 +26,24 @@ class PrsEligibilityService(
     var i = 0
     do {
       prisoners = prisonerSearchApiClient.findPrisonersByAgencyId(agencyId, i, PRISONERS_CHUNK_SIZE)
+      val sdsExcludedOffenceCodes = manageOffencesApiClient.checkWhichOffenceCodesAreSdsExcluded(getAllOffenceCodes(prisoners))?.map { it.offenceCode } ?: emptyList()
+      println(getAllOffenceCodes(prisoners))
       prisoners.forEach {
         allPrisonersPrsEligibility.addPrisoner(
-          (PrisonerPrsEligibilityCalculator(it)).calculate(),
+          (PrisonerPrsEligibilityCalculator(it, sdsExcludedOffenceCodes)).calculate(),
         )
       }
       i++
     } while (prisoners.count() >= PRISONERS_CHUNK_SIZE)
     allPrisonersPrsEligibility.logResult()
+  }
+
+  private fun getAllOffenceCodes(prisoners: List<Prisoner>): List<String> {
+    val offenceCodes = mutableListOf<String>()
+    prisoners.forEach { prisoner ->
+      prisoner.convictedOffencesResponse?.allConvictedOffences?.map { it.offenceCode }?.let { offenceCodes.addAll(it) }
+    }
+    return offenceCodes.distinct()
   }
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrisonerPrsEligibilityCalculatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrisonerPrsEligibilityCalculatorTest.kt
@@ -6,6 +6,8 @@ import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.factories.Tes
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.enum.PrsIneligibilityReason
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.Alert
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.ConvictedOffence
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.ConvictedOffencesResponse
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.CurrentIncentive
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.Level
 import java.time.LocalDate
@@ -14,17 +16,30 @@ class PrisonerPrsEligibilityCalculatorTest {
 
   @Test
   fun testCalculateWithEligiblePrisoner() {
+    val testOffenceCode = "SOMETHING"
     val prisonerPrsEligibilityCalculator = PrisonerPrsEligibilityCalculator(
       (TestPrisonerFactory())
         .withCategory(Prisoner.CATEGORY_C)
         .withCurrentIncentive(CurrentIncentive(Level(Prisoner.INCENTIVE_LEVEL_STANDARD, "Standard")))
         .withAlerts(null)
         .withReleaseDate(LocalDate.now().plusMonths(6))
+        .withConvictedOffencesResponse(
+          ConvictedOffencesResponse(
+            allConvictedOffences = listOf(
+              ConvictedOffence(
+                offenceCode = testOffenceCode,
+                offenceDescription = "something",
+              ),
+            ),
+          ),
+        )
         .build(),
+      listOf(testOffenceCode),
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).isEmpty()
     Assertions.assertThat(prisonerPrsEligibility.isEligible).isTrue()
+    Assertions.assertThat(prisonerPrsEligibility.sdsExcludedOffenceCodes).contains(testOffenceCode)
   }
 
   @Test
@@ -36,6 +51,7 @@ class PrisonerPrsEligibilityCalculatorTest {
         .withAlerts(null)
         .withReleaseDate(LocalDate.now().plusMonths(6))
         .build(),
+      emptyList(),
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).contains(PrsIneligibilityReason.CATEGORY)
@@ -51,6 +67,7 @@ class PrisonerPrsEligibilityCalculatorTest {
         .withAlerts(null)
         .withReleaseDate(LocalDate.now().plusMonths(6))
         .build(),
+      emptyList(),
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).contains(PrsIneligibilityReason.INCENTIVE_LEVEL)
@@ -66,6 +83,7 @@ class PrisonerPrsEligibilityCalculatorTest {
         .withAlerts(null)
         .withReleaseDate(LocalDate.now().plusMonths(13))
         .build(),
+      emptyList(),
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).contains(PrsIneligibilityReason.TIME_LEFT_TO_SERVE)
@@ -89,6 +107,7 @@ class PrisonerPrsEligibilityCalculatorTest {
         )
         .withReleaseDate(LocalDate.now().plusMonths(6))
         .build(),
+      emptyList(),
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).contains(PrsIneligibilityReason.ESCAPE)
@@ -112,6 +131,7 @@ class PrisonerPrsEligibilityCalculatorTest {
         )
         .withReleaseDate(LocalDate.now().plusMonths(13))
         .build(),
+      emptyList(),
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).containsAll(
@@ -142,6 +162,7 @@ class PrisonerPrsEligibilityCalculatorTest {
         )
         .withReleaseDate(LocalDate.now().plusMonths(6))
         .build(),
+      emptyList(),
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).isEmpty()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrsEligibilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrsEligibilityServiceTest.kt
@@ -15,7 +15,11 @@ import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.factories.Tes
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.factories.TestPrisonerFactory
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.SdsExcludedOffenceCode
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.*
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.Alert
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.ConvictedOffence
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.ConvictedOffencesResponse
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.CurrentIncentive
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.Level
 import java.time.LocalDate
 
 @ExtendWith(OutputCaptureExtension::class)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrsEligibilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrsEligibilityServiceTest.kt
@@ -8,14 +8,14 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.system.CapturedOutput
 import org.springframework.boot.test.system.OutputCaptureExtension
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.ManageOffencesApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.factories.TestPrisonFactory
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.factories.TestPrisonerFactory
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.Prisoner
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.Alert
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.CurrentIncentive
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.Level
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.SdsExcludedOffenceCode
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.*
 import java.time.LocalDate
 
 @ExtendWith(OutputCaptureExtension::class)
@@ -23,15 +23,19 @@ import java.time.LocalDate
 class PrsEligibilityServiceTest {
   private val mockPrisonerSearchApiClient = Mockito.mock<PrisonerSearchApiClient>()
   private val mockPrisonApiClient = Mockito.mock<PrisonApiClient>()
+  private val mockManageOffencesApiClient = Mockito.mock<ManageOffencesApiClient>()
 
   private val prsEligibilityService = PrsEligibilityService(
     mockPrisonerSearchApiClient,
     mockPrisonApiClient,
+    mockManageOffencesApiClient,
   )
 
   @Test
   fun testReport(output: CapturedOutput) {
     val testAgencyId = "HCI"
+    val testOffenceCode = "SOMETHING"
+    val testOffenceCode2 = "SOMETHING_ELSE"
 
     whenever(mockPrisonApiClient.findPrisons()).thenReturn(
       listOf(
@@ -45,6 +49,20 @@ class PrsEligibilityServiceTest {
           .withCurrentIncentive(CurrentIncentive(Level(Prisoner.INCENTIVE_LEVEL_STANDARD, "Standard")))
           .withAlerts(null)
           .withReleaseDate(LocalDate.now().plusMonths(6))
+          .withConvictedOffencesResponse(
+            ConvictedOffencesResponse(
+              allConvictedOffences = listOf(
+                ConvictedOffence(
+                  offenceCode = testOffenceCode,
+                  offenceDescription = "something",
+                ),
+                ConvictedOffence(
+                  offenceCode = testOffenceCode2,
+                  offenceDescription = "something else",
+                ),
+              ),
+            ),
+          )
           .build(),
         (TestPrisonerFactory())
           .withCategory(Prisoner.CATEGORY_B)
@@ -58,13 +76,31 @@ class PrsEligibilityServiceTest {
               ),
             ),
           )
+          .withConvictedOffencesResponse(
+            ConvictedOffencesResponse(
+              allConvictedOffences = listOf(
+                ConvictedOffence(
+                  offenceCode = testOffenceCode,
+                  offenceDescription = "something",
+                ),
+              ),
+            ),
+          )
           .withReleaseDate(LocalDate.now().plusMonths(13))
           .build(),
+      ),
+    )
+    whenever(mockManageOffencesApiClient.checkWhichOffenceCodesAreSdsExcluded(listOf(testOffenceCode, testOffenceCode2))).thenReturn(
+      listOf(
+        SdsExcludedOffenceCode(
+          offenceCode = testOffenceCode,
+          schedulePart = "something",
+        ),
       ),
     )
 
     prsEligibilityService.report()
 
-    Assertions.assertThat(output).contains("PRS_ELIGIBILITY_INVESTIGATION: HCI, 2, 1, 1, 1, 1, 1")
+    Assertions.assertThat(output).contains("PRS_ELIGIBILITY_INVESTIGATION: HCI, 2, 1, 0, CATEGORY: 1, TIME_LEFT_TO_SERVE: 1, INCENTIVE_LEVEL: 1, ESCAPE: 1, SOMETHING: 2")
   }
 }


### PR DESCRIPTION
Extending the job which is reporting via the logs on the number of current prisoners who would be eligibile for PRS based on certain criteria, we are not sure whether the SDS exemptions overlap fully with the PRS ones, so we want to log out which offence codes would count and how that would effect the number eligible.