### PR TITLE
PRS rosh and adjudications investigation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/config/ResourceServerConfiguration.kt
@@ -42,6 +42,7 @@ class ResourceServerConfiguration {
           "/swagger-resources/configuration/security",
           "/released-prisoners-with-active-categorisations/report",
           "/prs-eligibility/report",
+          "/prs-eligibility/report-prison",
         ).forEach { authorize(it, permitAll) }
         authorize(anyRequest, authenticated)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/enum/PrsIneligibilityReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/enum/PrsIneligibilityReason.kt
@@ -13,4 +13,6 @@ enum class PrsIneligibilityReason {
   OFFENCE_DOMESTIC_ABUSE,
   OFFENCE_SEXUAL_T3,
   OFFENCE_SEXUAL,
+  HIGH_ROSH,
+  ADJUDICATION,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/prs/AllPrisonersPrsEligibility.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/prs/AllPrisonersPrsEligibility.kt
@@ -7,6 +7,7 @@ class AllPrisonersPrsEligibility(
   private val agencyId: String,
   private var prisonerCount: Int = 0,
   private var prisonersEligible: Int = 0,
+  private var prisonersWithUnknownRosh: Int = 0,
   private var reasonsForIneligibility: MutableMap<PrsIneligibilityReason, Int> = mutableMapOf(),
 ) {
   fun addPrisoner(prisonerPrsEligibility: PrisonerPrsEligibility) {
@@ -14,13 +15,16 @@ class AllPrisonersPrsEligibility(
     if (prisonerPrsEligibility.isEligible) {
       prisonersEligible++
     }
+    if (prisonerPrsEligibility.unknownRosh) {
+      prisonersWithUnknownRosh++
+    }
     prisonerPrsEligibility.reasonForIneligibility.forEach {
       this.reasonsForIneligibility[it] = reasonsForIneligibility[it]?.plus(1) ?: 1
     }
   }
 
   fun logResult() {
-    val logStringBuilder = StringBuilder().append("PRS_ELIGIBILITY_INVESTIGATION: $agencyId, $prisonerCount, $prisonersEligible")
+    val logStringBuilder = StringBuilder().append("PRS_ELIGIBILITY_INVESTIGATION: $agencyId, $prisonerCount, $prisonersEligible, UnknownRosh: $prisonersWithUnknownRosh")
     this.reasonsForIneligibility.forEach {
       logStringBuilder.append(", ${it.key}: ${it.value}")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/prs/PrisonerPrsEligibility.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/prs/PrisonerPrsEligibility.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.enum.Pr
 
 class PrisonerPrsEligibility(
   val reasonForIneligibility: List<PrsIneligibilityReason>,
+  val unknownRosh: Boolean,
 ) {
   val isEligible: Boolean
     get() = reasonForIneligibility.isEmpty()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/response/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/response/Prisoner.kt
@@ -10,6 +10,7 @@ import java.time.LocalDate
 @Schema(description = "Prisoner")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class Prisoner(
+  val bookingId: Int? = null,
   val prisonerNumber: String? = null,
   val status: String? = null,
   val prisonId: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/response/probation/ProbationOtherIds.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/model/response/probation/ProbationOtherIds.kt
@@ -2,5 +2,5 @@ package uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.respon
 
 class ProbationOtherIds(
   val crn: String,
-  val prisonerNumber: String,
+  val nomsNumber: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/resource/PrsEligibility.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/resource/PrsEligibility.kt
@@ -5,6 +5,7 @@ import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.services.prs.PrsEligibilityService
 
@@ -23,4 +24,16 @@ class PrsEligibility(
   )
   fun reportPrsEligibility() =
     prsEligibilityService.report()
+
+  @GetMapping("/report-prison")
+  @Operation(
+    summary = "Report PRS eligibility for investigation purposes",
+    description = """Checks all prisoners at specified prison to see what number would be eligible for PRS
+      | using the criteria which is currently understood.
+    """,
+  )
+  fun reportPrsEligibilityForPrison(
+    @RequestParam(required = true) agencyId: String,
+  ) =
+    prsEligibilityService.report(agencyId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrisonerPrsEligibilityCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrisonerPrsEligibilityCalculator.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.services.prs
 
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.enum.PrsIneligibilityReason
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.enum.RiskLevel
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.enum.SdsExemptionSchedulePart
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.prs.PrisonerPrsEligibility
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.RiskSummary
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.SdsExcludedOffenceCode
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.Alert
 import java.time.LocalDate
@@ -11,6 +13,8 @@ import java.time.LocalDate
 class PrisonerPrsEligibilityCalculator(
   private val prisoner: Prisoner,
   private val sdsExcludedOffenceCodes: List<SdsExcludedOffenceCode>?,
+  private val riskSummary: RiskSummary?,
+  private val hasAdjudication: Boolean,
 ) {
   private fun isCategoryCOrClosed(): Boolean {
     return this.prisoner.category == Prisoner.CATEGORY_C || this.prisoner.category == Prisoner.CATEGORY_R
@@ -82,8 +86,15 @@ class PrisonerPrsEligibilityCalculator(
         reasonForIneligibility.add(ineligibilityReason)
       }
     }
+    if (riskSummary?.overallRiskLevel == RiskLevel.HIGH || riskSummary?.overallRiskLevel == RiskLevel.VERY_HIGH) {
+      reasonForIneligibility.add(PrsIneligibilityReason.HIGH_ROSH)
+    }
+    if (hasAdjudication) {
+      reasonForIneligibility.add(PrsIneligibilityReason.ADJUDICATION)
+    }
     return PrisonerPrsEligibility(
       reasonForIneligibility,
+      riskSummary == null,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrsEligibilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrsEligibilityService.kt
@@ -1,17 +1,24 @@
 package uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.services.prs
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.AssessRisksAndNeedsApiClient
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.ManageAdjudicationsApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.ManageOffencesApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PrisonerSearchApiClient
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.ProbationSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.prs.AllPrisonersPrsEligibility
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.RiskSummary
 
 @Service
 class PrsEligibilityService(
   private val prisonerSearchApiClient: PrisonerSearchApiClient,
   private val prisonApiClient: PrisonApiClient,
   private val manageOffencesApiClient: ManageOffencesApiClient,
+  private val probationSearchApiClient: ProbationSearchApiClient,
+  private val assessRisksAndNeedsApiClient: AssessRisksAndNeedsApiClient,
+  private val manageAdjudicationsApiClient: ManageAdjudicationsApiClient,
 ) {
   fun report() {
     val allPrisons = prisonApiClient.findPrisons()
@@ -27,9 +34,18 @@ class PrsEligibilityService(
     do {
       prisoners = prisonerSearchApiClient.findPrisonersByAgencyId(agencyId, i, PRISONERS_CHUNK_SIZE)
       val sdsExcludedOffenceCodes = manageOffencesApiClient.checkWhichOffenceCodesAreSdsExcluded(getAllOffenceCodes(prisoners))
+      val roshScores = getAllRoshScores(prisoners)
+      val prisonersWithAdjudications = getAllAdjudications(prisoners)
       prisoners.forEach {
         allPrisonersPrsEligibility.addPrisoner(
-          (PrisonerPrsEligibilityCalculator(it, sdsExcludedOffenceCodes)).calculate(),
+          (
+            PrisonerPrsEligibilityCalculator(
+              it,
+              sdsExcludedOffenceCodes,
+              roshScores[it.prisonerNumber],
+              prisonersWithAdjudications.contains(it.prisonerNumber),
+            )
+            ).calculate(),
         )
       }
       i++
@@ -43,6 +59,36 @@ class PrsEligibilityService(
       prisoner.allConvictedOffences?.map { it.offenceCode }?.let { offenceCodes.addAll(it) }
     }
     return offenceCodes.distinct()
+  }
+
+  private fun getAllRoshScores(prisoners: List<Prisoner>): Map<String, RiskSummary> {
+    val prisonerNumbers = prisoners.mapNotNull { it.prisonerNumber }
+    if (prisonerNumbers.isEmpty()) {
+      return emptyMap()
+    }
+    val crns = probationSearchApiClient.findProbationPersonsFromPrisonNumbers(prisonerNumbers).associate { it.otherIds.nomsNumber to it.otherIds.crn }
+    val roshSummaries = mutableMapOf<String, RiskSummary>()
+    crns.forEach {
+      if (it.key !== null) {
+        assessRisksAndNeedsApiClient.findRiskSummary(it.value)
+          ?.let { roshSummary -> roshSummaries[it.key!!] = roshSummary }
+      }
+    }
+    return roshSummaries
+  }
+
+  private fun getAllAdjudications(prisoners: List<Prisoner>): List<String> {
+    val bookingIds = prisoners.associate { it.bookingId to it.prisonerNumber }
+    val prisonerNumbersWithAdjudications = mutableListOf<String>()
+    bookingIds.forEach {
+      if (it.key !== null) {
+        val adjudicationsSummary = manageAdjudicationsApiClient.findAdjudicationsByBookingId(it.key!!)
+        if (adjudicationsSummary?.adjudicationCount !== null && adjudicationsSummary.adjudicationCount > 0 && it.value !== null) {
+          prisonerNumbersWithAdjudications.add(it.value!!)
+        }
+      }
+    }
+    return prisonerNumbersWithAdjudications
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrsEligibilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrsEligibilityService.kt
@@ -20,10 +20,10 @@ class PrsEligibilityService(
   private val assessRisksAndNeedsApiClient: AssessRisksAndNeedsApiClient,
   private val manageAdjudicationsApiClient: ManageAdjudicationsApiClient,
 ) {
-  fun report() {
-    val allPrisons = prisonApiClient.findPrisons()
+  fun report(agencyId: String? = null) {
+    val allPrisons = if (agencyId == null) prisonApiClient.findPrisons().map { it.agencyId } else listOf(agencyId)
     allPrisons.forEach {
-      reportPrisonerEligibilityForPrison(it.agencyId)
+      reportPrisonerEligibilityForPrison(it)
     }
   }
 

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -50,5 +50,5 @@ probation:
 api:
   client:
     admin:
-      id: dummy
-      secret: dummy
+      id: offender-categorisation-api-1
+      secret: Mu1wpQ.)!BpyCzptKEyW:TxQJi=O=*Odtzd4Azi<1>.0q$*ebKax+Zphffc1

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -50,5 +50,5 @@ probation:
 api:
   client:
     admin:
-      id: offender-categorisation-api-1
-      secret: Mu1wpQ.)!BpyCzptKEyW:TxQJi=O=*Odtzd4Azi<1>.0q$*ebKax+Zphffc1
+      id: dummy
+      secret: dummy

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/factories/TestPrisonerFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/factories/TestPrisonerFactory.kt
@@ -9,6 +9,7 @@ import java.time.LocalDate
 
 class TestPrisonerFactory {
   private var prisonerNumber = "123ABC"
+  private var bookingId = 12
   private var status = Prisoner.STATUS_ACTIVE_IN
   private var prisonId = "TEST"
   private var restrictedPatient = false
@@ -31,6 +32,11 @@ class TestPrisonerFactory {
 
   fun withPrisonerNumber(prisonerNumber: String): TestPrisonerFactory {
     this.prisonerNumber = prisonerNumber
+    return this
+  }
+
+  fun withBookingId(bookingId: Int): TestPrisonerFactory {
+    this.bookingId = bookingId
     return this
   }
 
@@ -102,5 +108,6 @@ class TestPrisonerFactory {
     legalStatus = this.legalStatus,
     allConvictedOffences = this.convictedOffences,
     alerts = this.alerts,
+    bookingId = this.bookingId,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrisonerPrsEligibilityCalculatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrisonerPrsEligibilityCalculatorTest.kt
@@ -4,8 +4,10 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.factories.TestPrisonerFactory
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.enum.PrsIneligibilityReason
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.enum.RiskLevel
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.enum.SdsExemptionSchedulePart
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.RiskSummary
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.SdsExcludedOffenceCode
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.Alert
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.ConvictedOffence
@@ -25,10 +27,13 @@ class PrisonerPrsEligibilityCalculatorTest {
         .withReleaseDate(LocalDate.now().plusMonths(6))
         .build(),
       emptyList(),
+      null,
+      false,
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).isEmpty()
     Assertions.assertThat(prisonerPrsEligibility.isEligible).isTrue()
+    Assertions.assertThat(prisonerPrsEligibility.unknownRosh).isTrue()
   }
 
   @Test
@@ -41,6 +46,8 @@ class PrisonerPrsEligibilityCalculatorTest {
         .withReleaseDate(LocalDate.now().plusMonths(6))
         .build(),
       emptyList(),
+      null,
+      false,
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).contains(PrsIneligibilityReason.CATEGORY)
@@ -57,6 +64,8 @@ class PrisonerPrsEligibilityCalculatorTest {
         .withReleaseDate(LocalDate.now().plusMonths(6))
         .build(),
       emptyList(),
+      null,
+      false,
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).contains(PrsIneligibilityReason.INCENTIVE_LEVEL)
@@ -73,6 +82,8 @@ class PrisonerPrsEligibilityCalculatorTest {
         .withReleaseDate(LocalDate.now().plusMonths(13))
         .build(),
       emptyList(),
+      null,
+      false,
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).contains(PrsIneligibilityReason.TIME_LEFT_TO_SERVE)
@@ -97,6 +108,8 @@ class PrisonerPrsEligibilityCalculatorTest {
         .withReleaseDate(LocalDate.now().plusMonths(6))
         .build(),
       emptyList(),
+      null,
+      false,
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).contains(PrsIneligibilityReason.ESCAPE)
@@ -121,6 +134,8 @@ class PrisonerPrsEligibilityCalculatorTest {
         .withReleaseDate(LocalDate.now().plusMonths(13))
         .build(),
       emptyList(),
+      null,
+      false,
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).containsAll(
@@ -152,6 +167,8 @@ class PrisonerPrsEligibilityCalculatorTest {
         .withReleaseDate(LocalDate.now().plusMonths(6))
         .build(),
       emptyList(),
+      null,
+      false,
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).isEmpty()
@@ -182,9 +199,71 @@ class PrisonerPrsEligibilityCalculatorTest {
           SdsExemptionSchedulePart.SEXUAL,
         ),
       ),
+      null,
+      false,
     )
     val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
     Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).contains(PrsIneligibilityReason.OFFENCE_SEXUAL)
+    Assertions.assertThat(prisonerPrsEligibility.isEligible).isFalse()
+  }
+
+  @Test
+  fun testCalculateWithHighRosh() {
+    val prisonerPrsEligibilityCalculator = PrisonerPrsEligibilityCalculator(
+      (TestPrisonerFactory())
+        .withCategory(Prisoner.CATEGORY_C)
+        .withCurrentIncentive(CurrentIncentive(Level(Prisoner.INCENTIVE_LEVEL_STANDARD, "Standard")))
+        .withAlerts(null)
+        .withReleaseDate(LocalDate.now().plusMonths(6))
+        .build(),
+      emptyList(),
+      RiskSummary(
+        RiskLevel.HIGH,
+      ),
+      false,
+    )
+    val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
+    Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).contains(PrsIneligibilityReason.HIGH_ROSH)
+    Assertions.assertThat(prisonerPrsEligibility.isEligible).isFalse()
+    Assertions.assertThat(prisonerPrsEligibility.unknownRosh).isFalse()
+  }
+
+  @Test
+  fun testCalculateWithLowRosh() {
+    val prisonerPrsEligibilityCalculator = PrisonerPrsEligibilityCalculator(
+      (TestPrisonerFactory())
+        .withCategory(Prisoner.CATEGORY_C)
+        .withCurrentIncentive(CurrentIncentive(Level(Prisoner.INCENTIVE_LEVEL_STANDARD, "Standard")))
+        .withAlerts(null)
+        .withReleaseDate(LocalDate.now().plusMonths(6))
+        .build(),
+      emptyList(),
+      RiskSummary(
+        RiskLevel.LOW,
+      ),
+      false,
+    )
+    val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
+    Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).isEmpty()
+    Assertions.assertThat(prisonerPrsEligibility.isEligible).isTrue()
+    Assertions.assertThat(prisonerPrsEligibility.unknownRosh).isFalse()
+  }
+
+  @Test
+  fun testCalculateWithAdjudications() {
+    val prisonerPrsEligibilityCalculator = PrisonerPrsEligibilityCalculator(
+      (TestPrisonerFactory())
+        .withCategory(Prisoner.CATEGORY_C)
+        .withCurrentIncentive(CurrentIncentive(Level(Prisoner.INCENTIVE_LEVEL_STANDARD, "Standard")))
+        .withAlerts(null)
+        .withReleaseDate(LocalDate.now().plusMonths(6))
+        .build(),
+      emptyList(),
+      null,
+      true,
+    )
+    val prisonerPrsEligibility = prisonerPrsEligibilityCalculator.calculate()
+    Assertions.assertThat(prisonerPrsEligibility.reasonForIneligibility).contains(PrsIneligibilityReason.ADJUDICATION)
     Assertions.assertThat(prisonerPrsEligibility.isEligible).isFalse()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrsEligibilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/prs/PrsEligibilityServiceTest.kt
@@ -8,18 +8,26 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.system.CapturedOutput
 import org.springframework.boot.test.system.OutputCaptureExtension
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.AssessRisksAndNeedsApiClient
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.ManageAdjudicationsApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.ManageOffencesApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PrisonerSearchApiClient
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.ProbationSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.factories.TestPrisonFactory
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.factories.TestPrisonerFactory
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.enum.RiskLevel
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.enum.SdsExemptionSchedulePart
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.RiskSummary
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.SdsExcludedOffenceCode
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.adjudication.AdjudicationsSummary
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.Alert
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.ConvictedOffence
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.CurrentIncentive
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.prisoner.Level
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.probation.ProbationOtherIds
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.probation.ProbationPerson
 import java.time.LocalDate
 
 @ExtendWith(OutputCaptureExtension::class)
@@ -28,18 +36,29 @@ class PrsEligibilityServiceTest {
   private val mockPrisonerSearchApiClient = Mockito.mock<PrisonerSearchApiClient>()
   private val mockPrisonApiClient = Mockito.mock<PrisonApiClient>()
   private val mockManageOffencesApiClient = Mockito.mock<ManageOffencesApiClient>()
+  private val mockProbationSearchApiClient = Mockito.mock<ProbationSearchApiClient>()
+  private val mockAssessRisksAndNeedsApiClient = Mockito.mock<AssessRisksAndNeedsApiClient>()
+  private val mockManageAdjudicationsApiClient = Mockito.mock<ManageAdjudicationsApiClient>()
 
   private val prsEligibilityService = PrsEligibilityService(
     mockPrisonerSearchApiClient,
     mockPrisonApiClient,
     mockManageOffencesApiClient,
+    mockProbationSearchApiClient,
+    mockAssessRisksAndNeedsApiClient,
+    mockManageAdjudicationsApiClient,
   )
 
   @Test
   fun testReport(output: CapturedOutput) {
     val testAgencyId = "HCI"
+    val testPrisonerNumber = "ABC123"
+    val testPrisonerNumber2 = "DEF456"
+    val testCrn = "CRN_TEST"
     val testOffenceCode = "SOMETHING"
     val testOffenceCode2 = "SOMETHING_ELSE"
+    val testBookingId = 12
+    val testBookingId2 = 13
 
     whenever(mockPrisonApiClient.findPrisons()).thenReturn(
       listOf(
@@ -49,6 +68,8 @@ class PrsEligibilityServiceTest {
     whenever(mockPrisonerSearchApiClient.findPrisonersByAgencyId(testAgencyId, 0, 100)).thenReturn(
       listOf(
         (TestPrisonerFactory())
+          .withPrisonerNumber(testPrisonerNumber)
+          .withBookingId(testBookingId)
           .withCategory(Prisoner.CATEGORY_C)
           .withCurrentIncentive(CurrentIncentive(Level(Prisoner.INCENTIVE_LEVEL_STANDARD, "Standard")))
           .withAlerts(null)
@@ -63,6 +84,8 @@ class PrsEligibilityServiceTest {
           )
           .build(),
         (TestPrisonerFactory())
+          .withPrisonerNumber(testPrisonerNumber2)
+          .withBookingId(testBookingId2)
           .withCategory(Prisoner.CATEGORY_B)
           .withCurrentIncentive(CurrentIncentive(Level(Prisoner.INCENTIVE_LEVEL_BASIC, "Basic")))
           .withAlerts(
@@ -102,9 +125,26 @@ class PrsEligibilityServiceTest {
         ),
       ),
     )
+    whenever(mockProbationSearchApiClient.findProbationPersonsFromPrisonNumbers(listOf(testPrisonerNumber, testPrisonerNumber2))).thenReturn(
+      listOf(
+        ProbationPerson(
+          otherIds = ProbationOtherIds(
+            crn = testCrn,
+            nomsNumber = testPrisonerNumber2,
+          ),
+        ),
+      ),
+    )
+    whenever(mockAssessRisksAndNeedsApiClient.findRiskSummary(testCrn)).thenReturn(RiskSummary(RiskLevel.HIGH))
+    whenever(mockManageAdjudicationsApiClient.findAdjudicationsByBookingId(testBookingId)).thenReturn(
+      AdjudicationsSummary(testBookingId, 0),
+    )
+    whenever(mockManageAdjudicationsApiClient.findAdjudicationsByBookingId(testBookingId2)).thenReturn(
+      AdjudicationsSummary(testBookingId, 4),
+    )
 
     prsEligibilityService.report()
 
-    Assertions.assertThat(output).contains("PRS_ELIGIBILITY_INVESTIGATION: HCI, 2, 1, CATEGORY: 1, TIME_LEFT_TO_SERVE: 1, INCENTIVE_LEVEL: 1, ESCAPE: 1, OFFENCE_SEXUAL: 1")
+    Assertions.assertThat(output).contains("PRS_ELIGIBILITY_INVESTIGATION: HCI, 2, 1, UnknownRosh: 1, CATEGORY: 1, TIME_LEFT_TO_SERVE: 1, INCENTIVE_LEVEL: 1, ESCAPE: 1, OFFENCE_SEXUAL: 1, HIGH_ROSH: 1, ADJUDICATION: 1")
   }
 }


### PR DESCRIPTION
Loading the rosh and adjudications data to see what effect these would have on PRS plus added an internal endpoint for testing this at a single prison rather than at all prisons.