### PR TITLE
Fix: use getUserLastName function in report

### DIFF
--- a/src/main/resources/templates/template_hmpps-offender-categorisation-api.mustache
+++ b/src/main/resources/templates/template_hmpps-offender-categorisation-api.mustache
@@ -22,8 +22,8 @@
         <tr>
             <td>{{ getPrisonName prisonId }}</td>
             <td>{{ optionalValue (formatDate start_date) }}</td>
-            <td>{{ optionalValue referred_by }}</td>
-            <td>{{ optionalValue user_id }}</td>
+            <td>{{ getUserLastName user_id }}</td>
+            <td>{{ optionalValue (getUserLastName referred_by) }}</td>
         </tr>
     </table>
 
@@ -36,9 +36,9 @@
         </tr>
         <tr>
             <td>{{ optionalValue (formatDate security_reviewed_date) }}</td>
-            <td>{{ optionalValue security_reviewed_by }}</td>
+            <td>{{ optionalValue (getUserLastName security_reviewed_by) }}</td>
             <td>{{ optionalValue (formatDate approval_date) }}</td>
-            <td>{{ optionalValue approved_by }}</td>
+            <td>{{ optionalValue (getUserLastName approved_by) }}</td>
         </tr>
     </table>
 
@@ -51,7 +51,7 @@
         </tr>
         <tr>
             <td>{{ optionalValue (formatDate assessment_date) }}</td>
-            <td>{{ optionalValue assessed_by }}</td>
+            <td>{{ optionalValue (getUserLastName assessed_by) }}</td>
             <td>{{ optionalValue (formatDate due_by_date) }}</td>
             <td>{{ optionalValue typeOfCategorisationAssessment }}</td>
         </tr>
@@ -64,7 +64,7 @@
         </tr>
         <tr>
             <td>{{ optionalValue (formatDate cancelled_date) }}</td>
-            <td>{{ optionalValue cancelled_by }}</td>
+            <td>{{ optionalValue (getUserLastName cancelled_by) }}</td>
         </tr>
     </table>
     <table class="data-table">
@@ -669,7 +669,7 @@
         <tr>
             <td>{{ getPrisonName prisonId }}</td>
             <td>{{ optionalValue (formatDate raised_date) }}</td>
-            <td>{{ optionalValue referredBy }}</td>
+            <td>{{ optionalValue (getUserLastName referredBy) }}</td>
             <td>{{ optionalValue (formatDate processed_date) }}</td>
             <td>{{ optionalValue status }}</td>
         </tr>
@@ -728,7 +728,7 @@
         <tr>
             <td>{{ optionalValue (formatDate created_date) }}</td>
             <td>{{ optionalValue (formatDate approved_date) }}</td>
-            <td>{{ optionalValue approved_by }}</td>
+            <td>{{ optionalValue (getUserLastName approved_by) }}</td>
             <td>{{ optionalValue (formatDate next_review_date) }}</td>
         </tr>
     </table>

--- a/src/test/resources/sar/sar-generated-report.html
+++ b/src/test/resources/sar/sar-generated-report.html
@@ -245,8 +245,8 @@
   <tr>
     <td>Moorland (HMP &amp; YOI)</td>
     <td>25 November 2019, 11:24:12 am</td>
-    <td>LBENNETT_GEN</td>
-    <td>SRENDELL_GEN</td>
+    <td>Johnson</td>
+    <td>Johnson</td>
   </tr>
 </table>
 
@@ -259,9 +259,9 @@
   </tr>
   <tr>
     <td>25 November 2019, 11:24:12 am</td>
-    <td>LBENNETT_GEN</td>
+    <td>Johnson</td>
     <td>25 June 2019</td>
-    <td>SRENDELL_GEN</td>
+    <td>Johnson</td>
   </tr>
 </table>
 
@@ -274,7 +274,7 @@
   </tr>
   <tr>
     <td>16 July 2019</td>
-    <td>SRENDELL_GEN</td>
+    <td>Johnson</td>
     <td>01 April 2017</td>
     <td>Initial</td>
   </tr>
@@ -287,7 +287,7 @@
   </tr>
   <tr>
     <td>25 November 2019, 11:24:12 am</td>
-    <td>SRENDELL_GEN</td>
+    <td>Johnson</td>
   </tr>
 </table>
 <table class="data-table">
@@ -554,8 +554,8 @@
   <tr>
     <td>Moorland (HMP &amp; YOI)</td>
     <td>25 November 2019, 11:24:12 am</td>
-    <td>LBENNETT_GEN</td>
-    <td>SRENDELL_GEN</td>
+    <td>Johnson</td>
+    <td>Johnson</td>
   </tr>
 </table>
 
@@ -568,9 +568,9 @@
   </tr>
   <tr>
     <td>25 November 2019, 11:24:12 am</td>
-    <td>LBENNETT_GEN</td>
+    <td>Johnson</td>
     <td>25 June 2019</td>
-    <td>SRENDELL_GEN</td>
+    <td>Johnson</td>
   </tr>
 </table>
 
@@ -583,7 +583,7 @@
   </tr>
   <tr>
     <td>16 July 2019</td>
-    <td>SRENDELL_GEN</td>
+    <td>Johnson</td>
     <td>01 April 2017</td>
     <td>Initial</td>
   </tr>
@@ -596,7 +596,7 @@
   </tr>
   <tr>
     <td>25 November 2019, 11:24:12 am</td>
-    <td>SRENDELL_GEN</td>
+    <td>Johnson</td>
   </tr>
 </table>
 <table class="data-table">
@@ -980,7 +980,7 @@
   <tr>
     <td>Moorland (HMP &amp; YOI)</td>
     <td>19 September 2019, 1:33:21 pm</td>
-    <td>LBENNETT_GEN</td>
+    <td>Johnson</td>
     <td>19 September 2019, 1:36:46 pm</td>
     <td>Referred</td>
   </tr>
@@ -1035,7 +1035,7 @@
       <tr>
         <td>18 May 2020, 1:58:42 pm</td>
         <td>18 May 2020, 1:00 am</td>
-        <td>CT_SUP</td>
+        <td>Johnson</td>
         <td>18 November 2020</td>
       </tr>
     </table>


### PR DESCRIPTION
This pull request updates the offender categorisation report templates to display user last names instead of user IDs or usernames in various places. Test HTML outputs are also updated to reflect these changes.