### PR TITLE
IR-1638: Migrate incident lookup from prison-api to incident-reporting-api

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     HMPPS_AUTH_TOKEN_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth/oauth/token
     PRISONER_SEARCH_API_ENDPOINT_URL: https://prisoner-search-dev.prison.service.justice.gov.uk
+    INCIDENT_API_ENDPOINT_URL: https://incident-reporting-api-dev.hmpps.service.justice.gov.uk
     PRISON_API_ENDPOINT_URL: https://prison-api-dev.prison.service.justice.gov.uk
     MANAGE_ADJUDICATIONS_API_ENDPOINT_URL: https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk
     ASSESS_RISKS_AND_NEEDS_API_ENDPOINT_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     HMPPS_AUTH_TOKEN_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/oauth/token
     PRISONER_SEARCH_API_ENDPOINT_URL: https://prisoner-search-preprod.prison.service.justice.gov.uk
+    INCIDENT_API_ENDPOINT_URL: https://incident-reporting-api-preprod.hmpps.service.justice.gov.uk
     PRISON_API_ENDPOINT_URL: https://prison-api-preprod.prison.service.justice.gov.uk
     MANAGE_ADJUDICATIONS_API_ENDPOINT_URL: https://manage-adjudications-api-preprod.hmpps.service.justice.gov.uk
     ASSESS_RISKS_AND_NEEDS_API_ENDPOINT_URL: https://assess-risks-and-needs-preprod.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,6 +9,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     HMPPS_AUTH_TOKEN_URL: https://sign-in.hmpps.service.justice.gov.uk/auth/oauth/token
     PRISONER_SEARCH_API_ENDPOINT_URL: https://prisoner-search.prison.service.justice.gov.uk
+    INCIDENT_API_ENDPOINT_URL: https://incident-reporting-api.hmpps.service.justice.gov.uk
     PRISON_API_ENDPOINT_URL: https://prison-api.prison.service.justice.gov.uk
     MANAGE_ADJUDICATIONS_API_ENDPOINT_URL: https://manage-adjudications-api.hmpps.service.justice.gov.uk
     ASSESS_RISKS_AND_NEEDS_API_ENDPOINT_URL: https://assess-risks-and-needs.hmpps.service.justice.gov.uk

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/client/IncidentApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/client/IncidentApiClient.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.util.UriBuilder
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentReport
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentReportResponse
 import java.time.LocalDate
@@ -18,18 +19,7 @@ class IncidentApiClient(
   fun getTotalNumberOfIncidents(prisonerNumber: String): Long = webClient.get()
     .uri { uriBuilder ->
       uriBuilder
-        .path("/incident-reports")
-        .queryParam("involvingPrisonerNumber", prisonerNumber)
-        .queryParam("type", "ASSAULT_1", "ASSAULT_5")
-        .queryParam(
-          "status",
-          "AWAITING_REVIEW",
-          "ON_HOLD",
-          "NEEDS_UPDATING",
-          "UPDATED",
-          "CLOSED",
-          "WAS_CLOSED",
-        )
+        .assaultReportsForPrisoner(prisonerNumber)
         .queryParam("size", "1")
         .build()
     }
@@ -44,18 +34,7 @@ class IncidentApiClient(
   ): List<UUID> = webClient.get()
     .uri { uriBuilder ->
       uriBuilder
-        .path("/incident-reports")
-        .queryParam("involvingPrisonerNumber", prisonerNumber)
-        .queryParam("type", "ASSAULT_1", "ASSAULT_5")
-        .queryParam(
-          "status",
-          "AWAITING_REVIEW",
-          "ON_HOLD",
-          "NEEDS_UPDATING",
-          "UPDATED",
-          "CLOSED",
-          "WAS_CLOSED",
-        )
+        .assaultReportsForPrisoner(prisonerNumber)
         .queryParam(
           "incidentDateFrom",
           LocalDate.now().minusMonths(recentAssaultMonths).format(DateTimeFormatter.ISO_LOCAL_DATE),
@@ -76,4 +55,34 @@ class IncidentApiClient(
     .retrieve()
     .bodyToMono(object : ParameterizedTypeReference<IncidentReport>() {})
     .block()!!
+
+  private fun UriBuilder.assaultReportsForPrisoner(prisonerNumber: String): UriBuilder = this
+    .path("/incident-reports")
+    .queryParam("involvingPrisonerNumber", prisonerNumber)
+    .queryParam("involvingPrisonerRole", *INVOLVING_PRISONER_ROLES)
+    .queryParam("type", *ASSAULT_TYPES)
+    .queryParam("status", *STATUSES)
+
+  companion object {
+    private val ASSAULT_TYPES = arrayOf("ASSAULT_1", "ASSAULT_5")
+
+    private val INVOLVING_PRISONER_ROLES = arrayOf(
+      "ACTIVE_INVOLVEMENT",
+      "ASSAILANT",
+      "FIGHTER",
+      "IMPEDED_STAFF",
+      "PERPETRATOR",
+      "SUSPECTED_ASSAILANT",
+      "SUSPECTED_INVOLVED",
+    )
+
+    private val STATUSES = arrayOf(
+      "AWAITING_REVIEW",
+      "ON_HOLD",
+      "NEEDS_UPDATING",
+      "UPDATED",
+      "CLOSED",
+      "WAS_CLOSED",
+    )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/client/IncidentApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/client/IncidentApiClient.kt
@@ -1,0 +1,79 @@
+package uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentReport
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentReportResponse
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+@Service
+class IncidentApiClient(
+  @Qualifier("incidentApiWebClient") private val webClient: WebClient,
+) {
+
+  fun getTotalNumberOfIncidents(prisonerNumber: String): Long = webClient.get()
+    .uri { uriBuilder ->
+      uriBuilder
+        .path("/incident-reports")
+        .queryParam("involvingPrisonerNumber", prisonerNumber)
+        .queryParam("type", "ASSAULT_1", "ASSAULT_5")
+        .queryParam(
+          "status",
+          "AWAITING_REVIEW",
+          "ON_HOLD",
+          "NEEDS_UPDATING",
+          "UPDATED",
+          "CLOSED",
+          "WAS_CLOSED",
+        )
+        .queryParam("size", "1")
+        .build()
+    }
+    .retrieve()
+    .bodyToMono(object : ParameterizedTypeReference<IncidentReportResponse>() {})
+    .block()!!.totalElements
+
+  fun getIncidentIds(
+    prisonerNumber: String,
+    recentAssaultMonths: Long,
+    size: Long,
+  ): List<UUID> = webClient.get()
+    .uri { uriBuilder ->
+      uriBuilder
+        .path("/incident-reports")
+        .queryParam("involvingPrisonerNumber", prisonerNumber)
+        .queryParam("type", "ASSAULT_1", "ASSAULT_5")
+        .queryParam(
+          "status",
+          "AWAITING_REVIEW",
+          "ON_HOLD",
+          "NEEDS_UPDATING",
+          "UPDATED",
+          "CLOSED",
+          "WAS_CLOSED",
+        )
+        .queryParam(
+          "incidentDateFrom",
+          LocalDate.now().minusMonths(recentAssaultMonths).format(DateTimeFormatter.ISO_LOCAL_DATE),
+        )
+        .queryParam("size", size.toString())
+        .build()
+    }
+    .retrieve()
+    .bodyToMono(object : ParameterizedTypeReference<IncidentReportResponse>() {})
+    .block()!!.content.map { it.id }
+
+  fun getDetailedIncidentReport(incidentId: UUID): IncidentReport = webClient.get()
+    .uri { uriBuilder ->
+      uriBuilder
+        .path("/incident-reports/$incidentId/with-details")
+        .build()
+    }
+    .retrieve()
+    .bodyToMono(object : ParameterizedTypeReference<IncidentReport>() {})
+    .block()!!
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/client/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/client/PrisonApiClient.kt
@@ -4,16 +4,6 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto.Companion.INCIDENT_TYPE_ASSAULT
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto.Companion.INCIDENT_TYPE_ASSAULTS3
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto.Companion.PARTICIPATION_ROLE_ACTINV
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto.Companion.PARTICIPATION_ROLE_ASSIAL
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto.Companion.PARTICIPATION_ROLE_FIGHT
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto.Companion.PARTICIPATION_ROLE_IMPED
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto.Companion.PARTICIPATION_ROLE_PERP
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto.Companion.PARTICIPATION_ROLE_SUSASS
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto.Companion.PARTICIPATION_ROLE_SUSINV
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.Prison
 
 @Service
@@ -24,26 +14,5 @@ class PrisonApiClient(
     .uri("/api/agencies/prisons")
     .retrieve()
     .bodyToMono(object : ParameterizedTypeReference<List<Prison>>() {})
-    .block()!!
-
-  fun getAssaultIncidents(prisonerNumber: String): List<IncidentDto> = webClient.get()
-    .uri { uriBuilder ->
-      uriBuilder
-        .path("api/offenders/$prisonerNumber/incidents")
-        .queryParam("incidentType", INCIDENT_TYPE_ASSAULT, INCIDENT_TYPE_ASSAULTS3)
-        .queryParam(
-          "participationRoles",
-          PARTICIPATION_ROLE_ACTINV,
-          PARTICIPATION_ROLE_ASSIAL,
-          PARTICIPATION_ROLE_FIGHT,
-          PARTICIPATION_ROLE_IMPED,
-          PARTICIPATION_ROLE_PERP,
-          PARTICIPATION_ROLE_SUSASS,
-          PARTICIPATION_ROLE_SUSINV,
-        )
-        .build()
-    }
-    .retrieve()
-    .bodyToMono(object : ParameterizedTypeReference<List<IncidentDto>>() {})
     .block()!!
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/config/WebClientConfiguration.kt
@@ -15,14 +15,15 @@ import org.springframework.web.reactive.function.client.WebClient
 
 @Configuration
 class WebClientConfiguration(
-  @Value("\${hmpps.auth.url}") private val oauthApiUrl: String,
-  @Value("\${prisoner.search.api.endpoint.url}") private val prisonerSearchApiBaseUrl: String,
-  @Value("\${manage.adjudications.api.endpoint.url}") private val manageAdjudicationsApiBaseUrl: String,
-  @Value("\${prison.api.endpoint.url}") private val prisonApiBaseUrl: String,
-  @Value("\${assess.risks.and.needs.api.endpoint.url}") private val assessRisksAndNeedsApiBaseUrl: String,
-  @Value("\${manage.offences.api.endpoint.url}") private val manageOffencesApiBaseUrl: String,
-  @Value("\${probation.search.api.endpoint.url}") private val probationSearchApiBaseUrl: String,
-  @Value("\${prisoner.alerts.api.endpoint.url}") private val prisonerAlertsApiBaseUri: String,
+  @Value($$"${hmpps.auth.url}") private val oauthApiUrl: String,
+  @Value($$"${prisoner.search.api.endpoint.url}") private val prisonerSearchApiBaseUrl: String,
+  @Value($$"${manage.adjudications.api.endpoint.url}") private val manageAdjudicationsApiBaseUrl: String,
+  @Value($$"${prison.api.endpoint.url}") private val prisonApiBaseUrl: String,
+  @Value($$"${incident.api.endpoint.url}") private val incidentApiBaseUrl: String,
+  @Value($$"${assess.risks.and.needs.api.endpoint.url}") private val assessRisksAndNeedsApiBaseUrl: String,
+  @Value($$"${manage.offences.api.endpoint.url}") private val manageOffencesApiBaseUrl: String,
+  @Value($$"${probation.search.api.endpoint.url}") private val probationSearchApiBaseUrl: String,
+  @Value($$"${prisoner.alerts.api.endpoint.url}") private val prisonerAlertsApiBaseUri: String,
   private val webClientBuilder: WebClient.Builder,
 ) {
   @Bean
@@ -75,6 +76,21 @@ class WebClientConfiguration(
         .build()
     return webClientBuilder
       .baseUrl(prisonApiBaseUrl)
+      .apply(oauth2Client.oauth2Configuration())
+      .exchangeStrategies(exchangeStrategies)
+      .build()
+  }
+
+  @Bean
+  fun incidentApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {
+    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
+    oauth2Client.setDefaultClientRegistrationId("incident-api")
+    val exchangeStrategies =
+      ExchangeStrategies.builder()
+        .codecs { configurer: ClientCodecConfigurer -> configurer.defaultCodecs().maxInMemorySize(-1) }
+        .build()
+    return webClientBuilder
+      .baseUrl(incidentApiBaseUrl)
       .apply(oauth2Client.oauth2Configuration())
       .exchangeStrategies(exchangeStrategies)
       .build()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/dto/incidents/IncidentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/dto/incidents/IncidentDto.kt
@@ -4,25 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Incident dto from prison API")
 data class IncidentDto(
-  @Schema(description = "Status of the incident", example = INCIDENT_STATUS_DUP)
+  @Schema(description = "Type of the incident", example = "ASSAULT_5")
+  val incidentType: String,
+  @Schema(description = "Status of the incident", example = "CLOSED")
   val incidentStatus: String,
-  @Schema(description = "Date time when the incident was reported", example = "2018-02-11T08:00:00")
-  val reportTime: String,
   @Schema(description = "List of questions and answers about the incident")
   val responses: List<IncidentResponseDto>,
-) {
-  companion object {
-    const val INCIDENT_TYPE_ASSAULT = "ASSAULT"
-    const val INCIDENT_TYPE_ASSAULTS3 = "ASSAULTS3"
-
-    const val PARTICIPATION_ROLE_ACTINV = "ACTINV"
-    const val PARTICIPATION_ROLE_ASSIAL = "ASSIAL"
-    const val PARTICIPATION_ROLE_FIGHT = "FIGHT"
-    const val PARTICIPATION_ROLE_IMPED = "IMPED"
-    const val PARTICIPATION_ROLE_PERP = "PERP"
-    const val PARTICIPATION_ROLE_SUSASS = "SUSASS"
-    const val PARTICIPATION_ROLE_SUSINV = "SUSINV"
-
-    const val INCIDENT_STATUS_DUP = "DUP"
-  }
-}
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/dto/incidents/IncidentReport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/dto/incidents/IncidentReport.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+open class IncidentReportResponse(
+  val content: List<ReportBasic>,
+  val totalElements: Long,
+)
+
+@Schema(description = "Incident report with only key information")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+open class ReportBasic(
+  val id: UUID,
+)
+
+@Schema(description = "Incident report with all related information")
+class IncidentReport(
+  id: UUID,
+  val type: String,
+  val status: String,
+  val questions: List<Question>,
+  val prisonersInvolved: List<PrisonerInvolvement>,
+) : ReportBasic(
+  id = id,
+)
+
+@Schema(description = "Question with responses making up an incident report")
+data class Question(
+  val code: String,
+  val question: String,
+  val responses: List<Response>,
+)
+
+@Schema(description = "Response to a question making up an incident report")
+data class Response(
+  val code: String,
+  val response: String,
+)
+
+@Schema(description = "Prisoner involved in an incident")
+data class PrisonerInvolvement(
+  val prisonerNumber: String,
+  val prisonerRole: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/dto/incidents/IncidentResponseDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/dto/incidents/IncidentResponseDto.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incident
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Incident response object nested within the incident dto from prison API")
+@Schema(description = "Incident response question and answer")
 data class IncidentResponseDto(
   @Schema(description = "Question asked within the incident", example = INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT)
   val question: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/risk/PrisonerRiskCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/risk/PrisonerRiskCalculator.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.services.risk
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.IncidentApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PrisonerAlertsApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentResponseDto
@@ -18,13 +18,12 @@ import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.prisonerA
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.risk.EscapeAlert
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.risk.PrisonerRiskProfile
 import java.time.Clock
-import java.time.LocalDateTime
 import java.time.ZonedDateTime
 
 @Service
 class PrisonerRiskCalculator(
   val prisonerAlertsApiClient: PrisonerAlertsApiClient,
-  val prisonApiClient: PrisonApiClient,
+  val incidentApiClient: IncidentApiClient,
   val viperService: ViperService,
   val clock: Clock,
 ) {
@@ -34,33 +33,74 @@ class PrisonerRiskCalculator(
       prisonerNumber,
       listOf(ALERT_CODE_ESCAPE_RISK, ALERT_CODE_ESCAPE_LIST, ALERT_CODE_ESCAPE_LIST_HEIGHTENED, ALERT_CODE_OCGM),
     )
-    val assaultIncidents = prisonApiClient.getAssaultIncidents(prisonerNumber)
+    val numberOfIncidents = incidentApiClient.getTotalNumberOfIncidents(prisonerNumber)
+
+    val assaultIncidents = if (numberOfIncidents > 0) {
+      getAssaultIncidents(
+        prisonerNumber = prisonerNumber,
+        recentAssaultMonths = RECENT_ASSAULT_MONTHS,
+        size = numberOfIncidents,
+      )
+    } else {
+      emptyList()
+    }
+
     val viperData = viperService.getViperData(prisonerNumber)
 
     return PrisonerRiskProfile(
       alerts.filter { it.alertCode.code == ALERT_CODE_ESCAPE_RISK && alertIsActiveAndNotExpired(it) }.map { EscapeAlert.mapFromDto(it, clock) }.toList(),
       alerts.filter { (it.alertCode.code == ALERT_CODE_ESCAPE_LIST || it.alertCode.code == ALERT_CODE_ESCAPE_LIST_HEIGHTENED) && alertIsActiveAndNotExpired(it) }.map { EscapeAlert.mapFromDto(it, clock) }.toList(),
-      !alerts.filter { it.alertCode.code == ALERT_CODE_OCGM && alertIsActiveAndNotExpired(it) }.isEmpty(),
-      viperData.aboveThreshold && numberOfAssaultIncidentsConsideredARisk(assaultIncidents),
+      !alerts.none { it.alertCode.code == ALERT_CODE_OCGM && alertIsActiveAndNotExpired(it) },
+      viperData.aboveThreshold && numberOfAssaultIncidentsConsideredARisk(numberOfIncidents, assaultIncidents),
     )
   }
 
-  private fun numberOfAssaultIncidentsConsideredARisk(assaultIncidents: List<IncidentDto>): Boolean {
-    val nonDuplicateAssaultIncidents = assaultIncidents.filter { it.incidentStatus != IncidentDto.INCIDENT_STATUS_DUP }
-    val recentNonDuplicateSeriousAssaults = nonDuplicateAssaultIncidents
-      .filter { LocalDateTime.parse(it.reportTime).isAfter(ZonedDateTime.now(clock).minusMonths(RECENT_ASSAULT_MONTHS).toLocalDateTime()) }
-      .count { incident: IncidentDto ->
-        incident.responses.any { response: IncidentResponseDto ->
-          listOf(
-            INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT,
-            INCIDENT_RESPONSE_QUESTION_CONCUSSION,
-            INCIDENT_RESPONSE_QUESTION_SERIOUS_INJURY,
-            INCIDENT_RESPONSE_QUESTION_RESULT_IN_HOSPITAL,
-          ).contains(response.question.uppercase()) &&
-            response.answer.uppercase() == INCIDENT_RESPONSE_ANSWER_YES
-        }
+  fun getAssaultIncidents(prisonerNumber: String, recentAssaultMonths: Long = RECENT_ASSAULT_MONTHS, size: Long = 6): List<IncidentDto> {
+    val incidentIds = incidentApiClient.getIncidentIds(prisonerNumber, recentAssaultMonths, size)
+
+    return incidentIds.map { incidentId ->
+      incidentApiClient.getDetailedIncidentReport(incidentId)
+    }.filter { incident ->
+      incident.prisonersInvolved.any { prisonerInvolvement ->
+        prisonerInvolvement.prisonerNumber == prisonerNumber &&
+          prisonerInvolvement.prisonerRole in listOf(
+            "ACTIVE_INVOLVEMENT",
+            "ASSAILANT",
+            "FIGHTER",
+            "IMPEDED_STAFF",
+            "PERPETRATOR",
+            "SUSPECTED_ASSAILANT",
+            "SUSPECTED_INVOLVED",
+          )
       }
-    return nonDuplicateAssaultIncidents.count() >= MINIMUM_NUMBER_OF_ASSAULTS_TO_CONSIDER_RISK && recentNonDuplicateSeriousAssaults > 0
+    }
+      .map { incident ->
+        IncidentDto(
+          incidentType = incident.type,
+          incidentStatus = incident.status,
+          responses = incident.questions.map { question ->
+            IncidentResponseDto(
+              question = question.question,
+              answer = question.responses.firstOrNull()?.response ?: "",
+            )
+          },
+        )
+      }
+  }
+
+  private fun numberOfAssaultIncidentsConsideredARisk(totalNumberOfIncidents: Long, assaultIncidents: List<IncidentDto>): Boolean {
+    val recentNonDuplicateSeriousAssaults = assaultIncidents.count { incident: IncidentDto ->
+      incident.responses.any { response: IncidentResponseDto ->
+        listOf(
+          INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT,
+          INCIDENT_RESPONSE_QUESTION_CONCUSSION,
+          INCIDENT_RESPONSE_QUESTION_SERIOUS_INJURY,
+          INCIDENT_RESPONSE_QUESTION_RESULT_IN_HOSPITAL,
+        ).contains(response.question.uppercase()) &&
+          response.answer.uppercase() == INCIDENT_RESPONSE_ANSWER_YES
+      }
+    }
+    return totalNumberOfIncidents >= MINIMUM_NUMBER_OF_ASSAULTS_TO_CONSIDER_RISK && recentNonDuplicateSeriousAssaults > 0
   }
 
   fun alertIsActiveAndNotExpired(alert: PrisonerAlertResponseDto): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/risk/PrisonerRiskCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/risk/PrisonerRiskCalculator.kt
@@ -60,19 +60,6 @@ class PrisonerRiskCalculator(
 
     return incidentIds.map { incidentId ->
       incidentApiClient.getDetailedIncidentReport(incidentId)
-    }.filter { incident ->
-      incident.prisonersInvolved.any { prisonerInvolvement ->
-        prisonerInvolvement.prisonerNumber == prisonerNumber &&
-          prisonerInvolvement.prisonerRole in listOf(
-            "ACTIVE_INVOLVEMENT",
-            "ASSAILANT",
-            "FIGHTER",
-            "IMPEDED_STAFF",
-            "PERPETRATOR",
-            "SUSPECTED_ASSAILANT",
-            "SUSPECTED_INVOLVED",
-          )
-      }
     }
       .map { incident ->
         IncidentDto(

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -36,6 +36,11 @@ prisoner:
       endpoint:
         url: "https://alerts-api-dev.hmpps.service.justice.gov.uk"
 
+incident:
+  api:
+    endpoint:
+      url: "https://incident-reporting-api-dev.hmpps.service.justice.gov.uk"
+
 prison:
   api:
     endpoint:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -21,6 +21,11 @@ prisoner:
       endpoint:
         url: "https://alerts-api-dev.hmpps.service.justice.gov.uk"
 
+incident:
+  api:
+    endpoint:
+      url: "https://incident-reporting-api-dev.hmpps.service.justice.gov.uk"
+
 prison:
   api:
     endpoint:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,11 @@ spring:
             client-secret: ${api.client.admin.secret}
             authorization-grant-type: client_credentials
             scope: read
+          incident-api:
+              provider: hmpps-auth
+              client-id: ${api.client.admin.id}
+              client-secret: ${api.client.admin.secret}
+              authorization-grant-type: client_credentials
           prison-api:
             provider: hmpps-auth
             client-id: ${api.client.admin.id}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/factories/dto/incidents/TestIncidentDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/factories/dto/incidents/TestIncidentDtoFactory.kt
@@ -4,8 +4,7 @@ import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentResponseDto
 
 class TestIncidentDtoFactory {
-  private var incidentStatus: String = IncidentDto.INCIDENT_STATUS_DUP
-  private var reportTime: String = "2020-01-01T10:00:00"
+  private var incidentStatus: String = "CLOSED"
   private var responses: List<IncidentResponseDto> = emptyList()
 
   fun withResponses(responses: List<IncidentResponseDto>): TestIncidentDtoFactory {
@@ -18,14 +17,9 @@ class TestIncidentDtoFactory {
     return this
   }
 
-  fun withReportTime(reportTime: String): TestIncidentDtoFactory {
-    this.reportTime = reportTime
-    return this
-  }
-
   fun build(): IncidentDto = IncidentDto(
+    incidentType = "ASSAULT_5",
     incidentStatus = this.incidentStatus,
-    reportTime = this.reportTime,
     responses = this.responses,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/integration/IntegrationTestBase.kt
@@ -48,6 +48,7 @@ abstract class IntegrationTestBase {
     private val pgContainer = PostgresContainer.instance
     internal val prisonerSearchMockServer = PrisonerSearchMockServer()
     internal val prisonApiMockServer = PrisonApiMockServer()
+    internal val incidentApiMockServer = IncidentApiMockServer()
     internal val manageAdjudicationsMockServer = ManageAdjudicationsMockServer()
     internal val assessRisksAndNeedsMockServer = AssessRisksAndNeedsMockServer()
     internal val manageOffencesMockServer = ManageOffencesMockServer()
@@ -73,6 +74,7 @@ abstract class IntegrationTestBase {
     @JvmStatic
     fun startMocks() {
       prisonerSearchMockServer.start()
+      incidentApiMockServer.start()
       prisonApiMockServer.start()
       manageAdjudicationsMockServer.start()
       assessRisksAndNeedsMockServer.start()
@@ -86,6 +88,7 @@ abstract class IntegrationTestBase {
     fun stopMocks() {
       prisonerSearchMockServer.stop()
       prisonApiMockServer.stop()
+      incidentApiMockServer.stop()
       manageAdjudicationsMockServer.stop()
       assessRisksAndNeedsMockServer.stop()
       manageOffencesMockServer.stop()
@@ -122,6 +125,15 @@ abstract class IntegrationTestBase {
       )
 
       prisonApiMockServer.stubFor(
+        WireMock.get("/health/ping").willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(if (status == 200) "pong" else "some error")
+            .withStatus(status),
+        ),
+      )
+
+      incidentApiMockServer.stubFor(
         WireMock.get("/health/ping").willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -168,6 +180,7 @@ abstract class IntegrationTestBase {
     hmppsAuthMockServer.resetAll()
     prisonerSearchMockServer.resetAll()
     prisonApiMockServer.resetAll()
+    incidentApiMockServer.resetAll()
     manageAdjudicationsMockServer.resetAll()
     assessRisksAndNeedsMockServer.resetAll()
     manageOffencesMockServer.resetAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/integration/LocalStackContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/integration/LocalStackContainer.kt
@@ -30,7 +30,7 @@ object LocalStackContainer {
     return LocalStackContainer(
       DockerImageName.parse("localstack/localstack").withTag("3"),
     ).apply {
-      withServices(LocalStackContainer.Service.SNS, LocalStackContainer.Service.SQS)
+      withServices(LocalStackContainer.Service.S3, LocalStackContainer.Service.SNS, LocalStackContainer.Service.SQS)
       withEnv("DEFAULT_REGION", "eu-west-2")
       waitingFor(
         Wait.forLogMessage(".*Ready.*", 1),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/integration/MockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/integration/MockServer.kt
@@ -8,9 +8,12 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.http.HttpHeader
 import com.github.tomakehurst.wiremock.http.HttpHeaders
+import org.springframework.data.jpa.domain.AbstractPersistable_.id
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PageableResult
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.SearchResult
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentReport
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentReportResponse
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.ReportBasic
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.prisonerAlert.PrisonerAlertResponseDto
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.factories.TestPrisonFactory
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.factories.TestPrisonerFactory
@@ -20,6 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.enum.Sd
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.Prison
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.model.response.adjudication.Adjudication
+import java.util.UUID
 import java.util.stream.Collectors
 
 private const val MAPPINGS_DIRECTORY = "src/testIntegration/resources"
@@ -81,6 +85,66 @@ class PrisonerSearchMockServer : MockServer(8091) {
   }
 }
 
+class IncidentApiMockServer : MockServer(8098) {
+
+  fun stubCountAssaultIncidents(numberOfIncidents: Long) {
+    stubFor(
+      WireMock.get(WireMock.urlPathEqualTo("/incident-reports"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(
+              jacksonObjectMapper().apply {
+                registerModule(JavaTimeModule())
+              }.writeValueAsString(
+                IncidentReportResponse(
+                  totalElements = numberOfIncidents,
+                  content = listOf(),
+                ),
+              ),
+            ),
+        ),
+    )
+  }
+
+  fun stubSearchAssaultIncidents(assaultIncidentIds: List<UUID>) {
+    stubFor(
+      WireMock.get(WireMock.urlPathEqualTo("/incident-reports"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(
+              jacksonObjectMapper().apply {
+                registerModule(JavaTimeModule())
+              }.writeValueAsString(
+                IncidentReportResponse(
+                  totalElements = assaultIncidentIds.size.toLong(),
+                  content = assaultIncidentIds.map { id ->
+                    ReportBasic(id = id)
+                  },
+                ),
+              ),
+            ),
+        ),
+    )
+  }
+
+  fun stubGetAssaultIncidentById(id: UUID, incidentReport: IncidentReport) {
+    stubFor(
+      WireMock.get(WireMock.urlPathEqualTo("/incident-reports/$id/with-details"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(
+              jacksonObjectMapper().apply {
+                registerModule(JavaTimeModule())
+              }.writeValueAsString(incidentReport),
+            ),
+        ),
+    )
+  }
+}
+
 class PrisonApiMockServer : MockServer(8094) {
   fun stubFindPrisons(prisons: List<Prison> = listOf((TestPrisonFactory()).build())) {
     stubFor(
@@ -92,21 +156,6 @@ class PrisonApiMockServer : MockServer(8094) {
               jacksonObjectMapper().apply {
                 registerModule(JavaTimeModule())
               }.writeValueAsString(prisons),
-            ),
-        ),
-    )
-  }
-
-  fun stubGetAssaultIncidents(prisonerNumber: String, assaultIncidents: List<IncidentDto>) {
-    stubFor(
-      WireMock.get(WireMock.urlPathEqualTo("/api/offenders/$prisonerNumber/incidents"))
-        .willReturn(
-          WireMock.aResponse()
-            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
-            .withBody(
-              jacksonObjectMapper().apply {
-                registerModule(JavaTimeModule())
-              }.writeValueAsString(assaultIncidents),
             ),
         ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/integration/PrisonerRiskPollerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/integration/PrisonerRiskPollerIntegrationTest.kt
@@ -38,9 +38,10 @@ class PrisonerRiskPollerIntegrationTest : IntegrationTestBase() {
           PrisonerAlertResponseDto.ALERT_CODE_ESCAPE_LIST_HEIGHTENED,
           PrisonerAlertResponseDto.ALERT_CODE_OCGM,
         ),
-        mutableListOf<PrisonerAlertResponseDto>(),
+        mutableListOf(),
       )
-      prisonApiMockServer.stubGetAssaultIncidents("ABC123", emptyList())
+      incidentApiMockServer.stubCountAssaultIncidents(0)
+      incidentApiMockServer.stubSearchAssaultIncidents(emptyList())
       webTestClient.get().uri("/prisoner-risk-calculation/poll-prisons")
         .accept(MediaType.APPLICATION_JSON)
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/risk/PrisonerRiskCalculatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/risk/PrisonerRiskCalculatorTest.kt
@@ -1,18 +1,25 @@
 package uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.services.risk
 
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.IncidentApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.client.PrisonerAlertsApiClient
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.config.ResourceTest
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto
-import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentDto.Companion.INCIDENT_STATUS_DUP
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentReport
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentResponseDto.Companion.INCIDENT_RESPONSE_ANSWER_YES
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentResponseDto.Companion.INCIDENT_RESPONSE_QUESTION_CONCUSSION
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentResponseDto.Companion.INCIDENT_RESPONSE_QUESTION_RESULT_IN_HOSPITAL
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentResponseDto.Companion.INCIDENT_RESPONSE_QUESTION_SERIOUS_INJURY
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.IncidentResponseDto.Companion.INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.PrisonerInvolvement
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.Question
+import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.incidents.Response
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.prisonerAlert.PrisonerAlertResponseDto
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.prisonerAlert.PrisonerAlertResponseDto.Companion.ALERT_CODE_ESCAPE_LIST
 import uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.dto.prisonerAlert.PrisonerAlertResponseDto.Companion.ALERT_CODE_ESCAPE_LIST_HEIGHTENED
@@ -30,17 +37,18 @@ import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.util.UUID
 import java.util.stream.Stream
 
 class PrisonerRiskCalculatorTest : ResourceTest() {
   private val mockPrisonerAlertsApiClient = mock<PrisonerAlertsApiClient>()
-  private val mockPrisonApiClient = mock<PrisonApiClient>()
+  private val mockIncidentApiClient = mock<IncidentApiClient>()
   private val mockViperService = mock<ViperService>()
   private val frozenDateTime = "2025-01-01T10:40:34Z"
   private val fixedClock = Clock.fixed(Instant.parse(frozenDateTime), ZoneId.of("UTC"))
   private val prisonerRiskCalculator = PrisonerRiskCalculator(
     mockPrisonerAlertsApiClient,
-    mockPrisonApiClient,
+    mockIncidentApiClient,
     mockViperService,
     fixedClock,
   )
@@ -56,6 +64,7 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
   @MethodSource("calculateRiskArguments")
   fun calculateRisk(
     alerts: List<PrisonerAlertResponseDto>,
+    numberOfIncidents: Long,
     incidents: List<IncidentDto>,
     viperResponse: ViperResponse,
     expectedEscapeRiskAlerts: List<EscapeAlert>,
@@ -69,7 +78,35 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
         alertCodes,
       ),
     ).thenReturn(alerts)
-    whenever(mockPrisonApiClient.getAssaultIncidents(TEST_PRISONER_NUMBER)).thenReturn(incidents)
+    whenever(mockIncidentApiClient.getTotalNumberOfIncidents(TEST_PRISONER_NUMBER)).thenReturn(numberOfIncidents)
+    val mapOfIncidents = incidents.associateBy { UUID.randomUUID() }
+    if (mapOfIncidents.isNotEmpty()) {
+      whenever(mockIncidentApiClient.getIncidentIds(TEST_PRISONER_NUMBER, 6, numberOfIncidents)).thenReturn(mapOfIncidents.keys.toList())
+      mapOfIncidents.forEach { (id, dto) ->
+        val generatedIncidentData = IncidentReport(
+          id = id,
+          type = dto.incidentType,
+          status = dto.incidentStatus,
+          questions = dto.responses.map { q ->
+            Question(
+              code = q.question,
+              question = q.question,
+              responses = listOf(Response(code = q.answer, response = q.answer)),
+            )
+          },
+          prisonersInvolved = listOf(
+            PrisonerInvolvement(
+              prisonerNumber = TEST_PRISONER_NUMBER,
+              prisonerRole = "ACTIVE_INVOLVEMENT",
+            ),
+          ),
+        )
+        whenever(mockIncidentApiClient.getDetailedIncidentReport(id)).thenReturn(
+          generatedIncidentData,
+        )
+      }
+    }
+
     whenever(mockViperService.getViperData(TEST_PRISONER_NUMBER)).thenReturn(viperResponse)
 
     val riskProfile = prisonerRiskCalculator.calculateRisk(TEST_PRISONER_NUMBER)
@@ -77,6 +114,67 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
     Assertions.assertThat(riskProfile.escapeListAlerts).isEqualTo(expectedEscapeListAlerts)
     Assertions.assertThat(riskProfile.riskDueToSeriousOrganisedCrime).isEqualTo(expectedRiskDueToSoc)
     Assertions.assertThat(riskProfile.riskDueToViolence).isEqualTo(expectedRiskDueToViolence)
+  }
+
+  @Test
+  fun `incident where prisoner has a non-active role is excluded from serious assault count`() {
+    val witnessIncidentId = UUID.randomUUID()
+    whenever(mockPrisonerAlertsApiClient.findPrisonerAlerts(TEST_PRISONER_NUMBER, alertCodes)).thenReturn(emptyList())
+    whenever(mockIncidentApiClient.getTotalNumberOfIncidents(TEST_PRISONER_NUMBER)).thenReturn(5L)
+    whenever(mockIncidentApiClient.getIncidentIds(TEST_PRISONER_NUMBER, 6L, 5L)).thenReturn(listOf(witnessIncidentId))
+    whenever(mockIncidentApiClient.getDetailedIncidentReport(witnessIncidentId)).thenReturn(
+      IncidentReport(
+        id = witnessIncidentId,
+        type = "ASSAULT_5",
+        status = "CLOSED",
+        questions = listOf(
+          Question(
+            code = INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT,
+            question = INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT,
+            responses = listOf(Response(code = INCIDENT_RESPONSE_ANSWER_YES, response = INCIDENT_RESPONSE_ANSWER_YES)),
+          ),
+        ),
+        prisonersInvolved = listOf(
+          PrisonerInvolvement(prisonerNumber = TEST_PRISONER_NUMBER, prisonerRole = "WITNESS"),
+        ),
+      ),
+    )
+    whenever(mockViperService.getViperData(TEST_PRISONER_NUMBER)).thenReturn(trueViperResponse)
+
+    val riskProfile = prisonerRiskCalculator.calculateRisk(TEST_PRISONER_NUMBER)
+
+    Assertions.assertThat(riskProfile.riskDueToViolence).isFalse()
+  }
+
+  @Test
+  fun `incident where active role belongs to a different prisoner is excluded from serious assault count`() {
+    val incidentId = UUID.randomUUID()
+    whenever(mockPrisonerAlertsApiClient.findPrisonerAlerts(TEST_PRISONER_NUMBER, alertCodes)).thenReturn(emptyList())
+    whenever(mockIncidentApiClient.getTotalNumberOfIncidents(TEST_PRISONER_NUMBER)).thenReturn(5L)
+    whenever(mockIncidentApiClient.getIncidentIds(TEST_PRISONER_NUMBER, 6L, 5L)).thenReturn(listOf(incidentId))
+    whenever(mockIncidentApiClient.getDetailedIncidentReport(incidentId)).thenReturn(
+      IncidentReport(
+        id = incidentId,
+        type = "ASSAULT_5",
+        status = "CLOSED",
+        questions = listOf(
+          Question(
+            code = INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT,
+            question = INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT,
+            responses = listOf(Response(code = INCIDENT_RESPONSE_ANSWER_YES, response = INCIDENT_RESPONSE_ANSWER_YES)),
+          ),
+        ),
+        prisonersInvolved = listOf(
+          PrisonerInvolvement(prisonerNumber = "DEF456", prisonerRole = "ASSAILANT"),
+          PrisonerInvolvement(prisonerNumber = TEST_PRISONER_NUMBER, prisonerRole = "WITNESS"),
+        ),
+      ),
+    )
+    whenever(mockViperService.getViperData(TEST_PRISONER_NUMBER)).thenReturn(trueViperResponse)
+
+    val riskProfile = prisonerRiskCalculator.calculateRisk(TEST_PRISONER_NUMBER)
+
+    Assertions.assertThat(riskProfile.riskDueToViolence).isFalse()
   }
 
   companion object {
@@ -113,6 +211,7 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
             .withCreatedAt(LocalDate.parse(ALERT_CREATED_AT_DATE))
             .build(),
         ),
+        0L,
         emptyList<IncidentDto>(),
         falseViperResponse,
         listOf(
@@ -150,6 +249,7 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
             .withCreatedAt(LocalDate.parse(ALERT_CREATED_AT_DATE))
             .build(),
         ),
+        0L,
         emptyList<IncidentDto>(),
         falseViperResponse,
         emptyList<EscapeAlert>(),
@@ -175,6 +275,7 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
             .withCreatedAt(LocalDate.parse(ALERT_CREATED_AT_DATE))
             .build(),
         ),
+        0L,
         emptyList<IncidentDto>(),
         falseViperResponse,
         emptyList<EscapeAlert>(),
@@ -193,6 +294,7 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
             .withCreatedAt(LocalDate.parse(ALERT_CREATED_AT_DATE))
             .build(),
         ),
+        0L,
         emptyList<IncidentDto>(),
         falseViperResponse,
         emptyList<EscapeAlert>(),
@@ -211,6 +313,7 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
             .withCreatedAt(LocalDate.parse(ALERT_CREATED_AT_DATE))
             .build(),
         ),
+        0L,
         emptyList<IncidentDto>(),
         falseViperResponse,
         emptyList<EscapeAlert>(),
@@ -229,6 +332,7 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
             .withCreatedAt(LocalDate.parse(ALERT_CREATED_AT_DATE))
             .build(),
         ),
+        0L,
         emptyList<IncidentDto>(),
         falseViperResponse,
         emptyList<EscapeAlert>(),
@@ -239,25 +343,15 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
       // 5 assaults total including one serious assault in last 6 months
       Arguments.of(
         emptyList<PrisonerAlertResponseDto>(),
+        5L,
         listOf(
           TestIncidentDtoFactory()
-            .withReportTime("2023-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .build(),
           TestIncidentDtoFactory()
-            .withReportTime("2022-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .build(),
           TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
-            .withIncidentStatus("SOMETHING")
-            .build(),
-          TestIncidentDtoFactory()
-            .withReportTime("2024-10-15T10:00:00")
-            .withIncidentStatus("SOMETHING")
-            .build(),
-          TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .withResponses(
               listOf(
@@ -278,25 +372,18 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
       // 5 assaults including one serious but one is a duplicate
       Arguments.of(
         emptyList<PrisonerAlertResponseDto>(),
+        4L,
         listOf(
           TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
-            .withIncidentStatus(INCIDENT_STATUS_DUP)
-            .build(),
-          TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .build(),
           TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .build(),
           TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .build(),
           TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .withResponses(
               listOf(
@@ -317,34 +404,19 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
       // 5 assaults total including one serious assault that is more than 6 months ago
       Arguments.of(
         emptyList<PrisonerAlertResponseDto>(),
+        5L,
         listOf(
           TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .build(),
           TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .build(),
           TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .build(),
           TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
-            .build(),
-          TestIncidentDtoFactory()
-            .withReportTime("2023-12-30T10:00:00")
-            .withIncidentStatus("SOMETHING")
-            .withResponses(
-              listOf(
-                TestIncidentResponseDtoFactory()
-                  .withQuestion(INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT)
-                  .withAnswer(INCIDENT_RESPONSE_ANSWER_YES)
-                  .build(),
-              ),
-            )
             .build(),
         ),
         trueViperResponse,
@@ -356,25 +428,15 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
       // more than 5 assaults with one serious but viper is below threshold
       Arguments.of(
         emptyList<PrisonerAlertResponseDto>(),
+        5L,
         listOf(
           TestIncidentDtoFactory()
-            .withReportTime("2023-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .build(),
           TestIncidentDtoFactory()
-            .withReportTime("2022-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .build(),
           TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
-            .withIncidentStatus("SOMETHING")
-            .build(),
-          TestIncidentDtoFactory()
-            .withReportTime("2024-10-15T10:00:00")
-            .withIncidentStatus("SOMETHING")
-            .build(),
-          TestIncidentDtoFactory()
-            .withReportTime("2024-12-15T10:00:00")
             .withIncidentStatus("SOMETHING")
             .withResponses(
               listOf(
@@ -391,6 +453,81 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
         emptyList<EscapeAlert>(),
         false,
         false,
+      ),
+      // 5 assaults total including one serious assault (concussion) in last 6 months
+      Arguments.of(
+        emptyList<PrisonerAlertResponseDto>(),
+        5L,
+        listOf(
+          TestIncidentDtoFactory().withIncidentStatus("SOMETHING").build(),
+          TestIncidentDtoFactory().withIncidentStatus("SOMETHING").build(),
+          TestIncidentDtoFactory()
+            .withIncidentStatus("SOMETHING")
+            .withResponses(
+              listOf(
+                TestIncidentResponseDtoFactory()
+                  .withQuestion(INCIDENT_RESPONSE_QUESTION_CONCUSSION)
+                  .withAnswer(INCIDENT_RESPONSE_ANSWER_YES)
+                  .build(),
+              ),
+            )
+            .build(),
+        ),
+        trueViperResponse,
+        emptyList<EscapeAlert>(),
+        emptyList<EscapeAlert>(),
+        false,
+        true,
+      ),
+      // 5 assaults total including one serious assault (serious injury) in last 6 months
+      Arguments.of(
+        emptyList<PrisonerAlertResponseDto>(),
+        5L,
+        listOf(
+          TestIncidentDtoFactory().withIncidentStatus("SOMETHING").build(),
+          TestIncidentDtoFactory().withIncidentStatus("SOMETHING").build(),
+          TestIncidentDtoFactory()
+            .withIncidentStatus("SOMETHING")
+            .withResponses(
+              listOf(
+                TestIncidentResponseDtoFactory()
+                  .withQuestion(INCIDENT_RESPONSE_QUESTION_SERIOUS_INJURY)
+                  .withAnswer(INCIDENT_RESPONSE_ANSWER_YES)
+                  .build(),
+              ),
+            )
+            .build(),
+        ),
+        trueViperResponse,
+        emptyList<EscapeAlert>(),
+        emptyList<EscapeAlert>(),
+        false,
+        true,
+      ),
+      // 5 assaults total including one serious assault (resulted in hospital) in last 6 months
+      Arguments.of(
+        emptyList<PrisonerAlertResponseDto>(),
+        5L,
+        listOf(
+          TestIncidentDtoFactory().withIncidentStatus("SOMETHING").build(),
+          TestIncidentDtoFactory().withIncidentStatus("SOMETHING").build(),
+          TestIncidentDtoFactory()
+            .withIncidentStatus("SOMETHING")
+            .withResponses(
+              listOf(
+                TestIncidentResponseDtoFactory()
+                  .withQuestion(INCIDENT_RESPONSE_QUESTION_RESULT_IN_HOSPITAL)
+                  .withAnswer(INCIDENT_RESPONSE_ANSWER_YES)
+                  .build(),
+              ),
+            )
+            .build(),
+        ),
+        trueViperResponse,
+        emptyList<EscapeAlert>(),
+        emptyList<EscapeAlert>(),
+        false,
+        true,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/risk/PrisonerRiskCalculatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoffendercategorisationapi/services/risk/PrisonerRiskCalculatorTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsoffendercategorisationapi.services.risk
 
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -114,67 +113,6 @@ class PrisonerRiskCalculatorTest : ResourceTest() {
     Assertions.assertThat(riskProfile.escapeListAlerts).isEqualTo(expectedEscapeListAlerts)
     Assertions.assertThat(riskProfile.riskDueToSeriousOrganisedCrime).isEqualTo(expectedRiskDueToSoc)
     Assertions.assertThat(riskProfile.riskDueToViolence).isEqualTo(expectedRiskDueToViolence)
-  }
-
-  @Test
-  fun `incident where prisoner has a non-active role is excluded from serious assault count`() {
-    val witnessIncidentId = UUID.randomUUID()
-    whenever(mockPrisonerAlertsApiClient.findPrisonerAlerts(TEST_PRISONER_NUMBER, alertCodes)).thenReturn(emptyList())
-    whenever(mockIncidentApiClient.getTotalNumberOfIncidents(TEST_PRISONER_NUMBER)).thenReturn(5L)
-    whenever(mockIncidentApiClient.getIncidentIds(TEST_PRISONER_NUMBER, 6L, 5L)).thenReturn(listOf(witnessIncidentId))
-    whenever(mockIncidentApiClient.getDetailedIncidentReport(witnessIncidentId)).thenReturn(
-      IncidentReport(
-        id = witnessIncidentId,
-        type = "ASSAULT_5",
-        status = "CLOSED",
-        questions = listOf(
-          Question(
-            code = INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT,
-            question = INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT,
-            responses = listOf(Response(code = INCIDENT_RESPONSE_ANSWER_YES, response = INCIDENT_RESPONSE_ANSWER_YES)),
-          ),
-        ),
-        prisonersInvolved = listOf(
-          PrisonerInvolvement(prisonerNumber = TEST_PRISONER_NUMBER, prisonerRole = "WITNESS"),
-        ),
-      ),
-    )
-    whenever(mockViperService.getViperData(TEST_PRISONER_NUMBER)).thenReturn(trueViperResponse)
-
-    val riskProfile = prisonerRiskCalculator.calculateRisk(TEST_PRISONER_NUMBER)
-
-    Assertions.assertThat(riskProfile.riskDueToViolence).isFalse()
-  }
-
-  @Test
-  fun `incident where active role belongs to a different prisoner is excluded from serious assault count`() {
-    val incidentId = UUID.randomUUID()
-    whenever(mockPrisonerAlertsApiClient.findPrisonerAlerts(TEST_PRISONER_NUMBER, alertCodes)).thenReturn(emptyList())
-    whenever(mockIncidentApiClient.getTotalNumberOfIncidents(TEST_PRISONER_NUMBER)).thenReturn(5L)
-    whenever(mockIncidentApiClient.getIncidentIds(TEST_PRISONER_NUMBER, 6L, 5L)).thenReturn(listOf(incidentId))
-    whenever(mockIncidentApiClient.getDetailedIncidentReport(incidentId)).thenReturn(
-      IncidentReport(
-        id = incidentId,
-        type = "ASSAULT_5",
-        status = "CLOSED",
-        questions = listOf(
-          Question(
-            code = INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT,
-            question = INCIDENT_RESPONSE_QUESTION_SEXUAL_ASSAULT,
-            responses = listOf(Response(code = INCIDENT_RESPONSE_ANSWER_YES, response = INCIDENT_RESPONSE_ANSWER_YES)),
-          ),
-        ),
-        prisonersInvolved = listOf(
-          PrisonerInvolvement(prisonerNumber = "DEF456", prisonerRole = "ASSAILANT"),
-          PrisonerInvolvement(prisonerNumber = TEST_PRISONER_NUMBER, prisonerRole = "WITNESS"),
-        ),
-      ),
-    )
-    whenever(mockViperService.getViperData(TEST_PRISONER_NUMBER)).thenReturn(trueViperResponse)
-
-    val riskProfile = prisonerRiskCalculator.calculateRisk(TEST_PRISONER_NUMBER)
-
-    Assertions.assertThat(riskProfile.riskDueToViolence).isFalse()
   }
 
   companion object {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -31,6 +31,12 @@ prisoner:
       endpoint:
         url: http://localhost:8097
 
+incident:
+  api:
+    endpoint:
+      url:
+        http://localhost:8098
+
 prison:
   api:
     endpoint:


### PR DESCRIPTION
# IR-1638: Migrate incident lookup from prison-api to incident-reporting-api

## Summary

Replaces the legacy `prison-api` incident endpoint (`/api/offenders/{prisonerNumber}/incidents`) with the new `incident-reporting-api` service for the prisoner risk categorisation profile. The data retrieved is equivalent — assault incidents involving a prisoner — but the mechanism has changed to use dedicated API calls with server-side filtering. The business logic determining whether a prisoner poses a violence risk remains unchanged.

## Background

The `PrisonerRiskCalculator` determines whether a prisoner poses an assault risk as part of the risk profiling workflow. A prisoner is considered a violence risk if:
1. They have **5 or more** assault incidents on record in total, AND
2. At least **one serious assault** occurred in the **last 6 months**, AND
3. Their VIPER score is above the threshold.

Previously both conditions were evaluated using a single call to `prison-api` which returned a flat list. The new `incident-reporting-api` separates these concerns: a count call establishes the total, and a date-filtered call retrieves the recent incident detail for seriousness assessment.

## Changes

### Updated: `IncidentApiClient` (refactored to three focused methods)

The client is intentionally kept "dumb" — it handles HTTP concerns only, with no business logic. All mapping has moved to `PrisonerRiskCalculator`; all filtering is now performed server-side by `incident-reporting-api`.

A shared private extension function `UriBuilder.assaultReportsForPrisoner(prisonerNumber)` applies the common filter set used by both `getTotalNumberOfIncidents` and `getIncidentIds`:
- `involvingPrisonerNumber` — the prisoner under assessment
- `involvingPrisonerRole` — restricts the result to incidents where the prisoner has an active role: `ACTIVE_INVOLVEMENT`, `ASSAILANT`, `FIGHTER`, `IMPEDED_STAFF`, `PERPETRATOR`, `SUSPECTED_ASSAILANT`, `SUSPECTED_INVOLVED`. This filter is **essential for the total count** to be correct — a prisoner who has been a witness to incidents should not have those counted toward the "≥ 5 assaults" threshold. (Requires the corresponding update to `incident-reporting-api` that adds support for the `involvingPrisonerRole` query parameter.)
- `type` — `ASSAULT_1`, `ASSAULT_5`
- `status` — `AWAITING_REVIEW`, `ON_HOLD`, `NEEDS_UPDATING`, `UPDATED`, `CLOSED`, `WAS_CLOSED`

**`getTotalNumberOfIncidents(prisonerNumber)`**

Calls `GET /incident-reports` with `size=1` (to minimise payload) and returns `totalElements` from the paginated response. No date filter — this is the all-time total of qualifying assaults used for the "≥ 5 assaults" threshold.

**`getIncidentIds(prisonerNumber, recentAssaultMonths, size)`**

Calls `GET /incident-reports` with `incidentDateFrom` set to 6 months ago and `size` set to the total count from the previous call. Returns the list of report UUIDs. This replaces the client-side date filter that previously used `reportTime`.

**`getDetailedIncidentReport(incidentId)`**

Calls `GET /incident-reports/{id}/with-details` and returns the full `IncidentReport` including questions, responses, and prisoner involvement records.

### Updated: `PrisonerRiskCalculator`

The calculator now owns the multi-step incident lookup and all business mapping:

1. Calls `getTotalNumberOfIncidents` — short-circuits to no violence risk if count is 0
2. If count > 0, calls `getAssaultIncidents` (see below) to get recent detailed incidents
3. Evaluates `numberOfAssaultIncidentsConsideredARisk(totalCount, recentIncidents)`:
   - `totalCount >= 5` (threshold check uses the all-time count, not just recent)
   - At least one recent incident has a serious assault question answered `YES`

**`getAssaultIncidents(prisonerNumber, recentAssaultMonths, size)`** (internal helper)

Calls `getIncidentIds` then fetches each report with `getDetailedIncidentReport` and maps the result to the existing `IncidentDto` shape. No client-side role or prisoner filtering — that responsibility now lives at the API layer via the `involvingPrisonerRole` and `involvingPrisonerNumber` query parameters.

### Updated: `PrisonApiClient`

Removed `getAssaultIncidents()` and all associated incident-related imports. The client now only retains `findPrisons()`.

### New: `IncidentReport.kt` (DTOs)

New response model classes for the `incident-reporting-api` payload:

| Class | Purpose |
|---|---|
| `IncidentReportResponse` | Paginated wrapper; exposes `content` (list of reports) and `totalElements` |
| `ReportBasic` | Minimal projection (UUID only) from list endpoint |
| `IncidentReport` | Full detail from `with-details` endpoint |
| `Question` / `Response` | Nested Q&A within a report |
| `PrisonerInvolvement` | Prisoner role within a report |

### Updated: `IncidentDto`

- Added `incidentType` field (populated from `IncidentReport.type`)
- Removed `reportTime` field (date filtering is now handled by the `incidentDateFrom` API parameter)
- Removed companion object constants for legacy prison-api incident types, participation roles, and `INCIDENT_STATUS_DUP` (all superseded by the new role filtering in `PrisonerRiskCalculator`)

### Configuration

**`WebClientConfiguration`**
- New `incidentApiWebClient` bean using the `incident-api` OAuth2 client registration
- New `incident.api.endpoint.url` property injected via `@Value`

**`application.yml`**
- New `incident-api` OAuth2 client registration under `spring.security.oauth2.client.registration` (client credentials, `hmpps-auth` provider)

**`application-dev.yml` / `application-local.yaml`**
- Added `incident.api.endpoint.url: https://incident-reporting-api-dev.hmpps.service.justice.gov.uk`

**Helm values**

| Environment | URL added |
|---|---|
| dev | `https://incident-reporting-api-dev.hmpps.service.justice.gov.uk` |
| preprod | `https://incident-reporting-api-preprod.hmpps.service.justice.gov.uk` |
| prod | `https://incident-reporting-api.hmpps.service.justice.gov.uk` |

### Tests

**Unit tests (`PrisonerRiskCalculatorTest`)** — 13 parameterised scenarios

Mocks updated from `PrisonApiClient` to `IncidentApiClient`'s three new methods. The test stubs `getTotalNumberOfIncidents` (returning the all-time count) separately from `getIncidentIds` / `getDetailedIncidentReport` (returning recent detail), reflecting the real two-phase call.

Role-based filtering scenarios are no longer covered at the calculator layer — that responsibility has moved to `incident-reporting-api`, and the corresponding test cases have been removed. The role filter is exercised indirectly through the `involvingPrisonerRole` query parameter assembled in `IncidentApiClient.assaultReportsForPrisoner()`.

*Scenarios covered:*
- Active/inactive/expired escape risk, escape list, and OCGM alerts
- 5 total incidents with 1 recent serious assault (sexual assault) → violence risk = true
- 4 total incidents with 1 recent serious assault → violence risk = false (below threshold)
- 5 total incidents with no serious assaults in last 6 months → violence risk = false
- 5 total incidents with 1 recent serious assault but VIPER below threshold → violence risk = false
- 5 total incidents with 1 recent serious assault (concussion) → violence risk = true
- 5 total incidents with 1 recent serious assault (serious injury) → violence risk = true
- 5 total incidents with 1 recent serious assault (resulted in hospital) → violence risk = true

**Integration tests (`MockServer.kt` / `IntegrationTestBase`)**
- New `IncidentApiMockServer` (WireMock, port 8098) added to `MockServer.kt`
  - `stubCountAssaultIncidents(numberOfIncidents)` — stubs `GET /incident-reports` returning a `totalElements` count with empty content (for the count-only call)
  - `stubSearchAssaultIncidents(ids)` — stubs `GET /incident-reports` returning a paginated list of UUIDs
  - `stubGetAssaultIncidentById(id, report)` — stubs `GET /incident-reports/{id}/with-details` returning a single `IncidentReport`
- `IncidentApiMockServer` registered in `IntegrationTestBase` (start/stop/reset lifecycle, health ping stub)
- `PrisonerRiskPollerIntegrationTest` updated to stub against `incidentApiMockServer`
- `application-test.yml` — new `incident.api.endpoint.url: http://localhost:8098`

**Test factory (`TestIncidentDtoFactory`)**
- Removed `withReportTime()` builder method and `reportTime` field (field removed from `IncidentDto`)
- Default `incidentStatus` updated from `DUP` → `CLOSED`
- Added `incidentType` defaulting to `ASSAULT_5`

## API Reference

- List reports / count: `GET /incident-reports` — [Swagger (dev)](https://incident-reporting-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html#/Incident%20reports/getBasicReports)
- Report detail: `GET /incident-reports/{id}/with-details` — [Swagger (dev)](https://incident-reporting-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html#/Incident%20reports/getReportWithDetailsById)

## Testing

- [x] Unit tests pass (`PrisonerRiskCalculatorTest` — 13 tests)
- [x] Integration tests pass (`PrisonerRiskPollerIntegrationTest`)
- [ ] Smoke test against dev environment to confirm incident data is returned correctly for a known prisoner with assault history
